### PR TITLE
Typo in array type checking

### DIFF
--- a/kublai.js
+++ b/kublai.js
@@ -22,7 +22,7 @@
 	mbtiles.registerProtocols(tilelive);
 	
 	function arrayEquality(a,b){
-		if(!(Array.isArray(a)&&Array.isArray(a))){
+		if(!(Array.isArray(a)&&Array.isArray(b))){
 			return false;
 		}else if(a.length!==b.length){
 			return false;


### PR DESCRIPTION
This is just a hotfix where the same object `a` was being checked twice rather than what I presume should have been `a` and `b`.
